### PR TITLE
feat: add plugin mode for automatic collection encryption

### DIFF
--- a/packages/encrypted-fields/README.md
+++ b/packages/encrypted-fields/README.md
@@ -2,33 +2,67 @@
 
 ## Install
 
-`pnpm add @oversightstudio/encrypted-fields @payloadcms/ui`
+```bash
+pnpm add @oversightstudio/encrypted-fields @payloadcms/ui
+```
 
 ## About
-This package brings encrypted fields to Payload. It provides an `encryptedField` function that allows you to easily add encrypted fields to your collections.
+This package brings encrypted fields to Payload. It provides two ways to encrypt fields:
 
-It supports most field field types, including ones like `select` or `number` with `hasMany` enabled. Additionally, it fully integrates with Payload’s field customization options and lifecycle events, making it behave just like any other field—just encrypted.
+1. **Plugin Mode**: Automatically encrypt all supported fields in specified collections
+2. **Field Mode**: Manually wrap individual fields with the `encryptedField` function
 
-The package automatically encrypts and decrypts field values using hooks, meaning you don’t need any extra setup to use encrypted fields in the admin panel or through the API.
+Both approaches use **AES-256-CTR** encryption with either a secret you provide in the plugin options or your `PAYLOAD_SECRET` environment variable.
+
+The package automatically encrypts and decrypts field values using hooks, making it seamless to use in both the admin panel and API.
 
 ### Encryption
-This package uses **AES-256-CTR** encryption, combined with your `PAYLOAD_SECRET` and a random IV. The encrypted value is stored as a string in the database.
+This package uses **AES-256-CTR** encryption, combined with your encryption secret and a random IV. The encrypted value is stored as a string in the database.
 
 For a deeper dive into how this encryption works, check out [this blog post](https://payloadcms.com/posts/blog/the-power-of-encryption-and-decryption-safeguarding-data-privacy-with-payloads-hooks) by Payload. It explains the same encryption approach but for a simple text field. This package expands on that to support more field types and make integration seamless.
 
-Since encryption fundamentally converts data into an unreadable format, this package JSON stringifies your data before encrypting it and automatically parses it back after decryption to retain it's original data type.  
+Since encryption fundamentally converts data into an unreadable format, this package JSON stringifies your data before encrypting it and automatically parses it back after decryption to retain its original data type.
 
-### Tradeofs
+### Tradeoffs
 Using field encryption comes with some tradeoffs:  
 - **Larger data size** – Encrypted values take up more space than raw values.  
 - **No sorting or filtering** – Since the data is encrypted at rest, the database **cannot** sort or filter it.  
 - **Performance overhead** – Encrypting and decrypting data adds some processing time.  
 
-These tradeoffs are standard when working with encrypted data, but they’re well worth it if protecting sensitive information is your goal.  
+These tradeoffs are standard when working with encrypted data, but they're well worth it if protecting sensitive information is your goal.
 
 ## Usage
 
-**Important:** Make sure the `PAYLOAD_SECRET` environment variable is set before using this package.
+**Important:** Make sure to provide a secret key for encryption, either by setting the `PAYLOAD_SECRET` environment variable or by passing a `secret` option to the plugin.
+
+### Plugin Mode (Recommended)
+
+The easiest way to use encrypted fields is through the plugin. This automatically encrypts all supported fields in the collections you specify:
+
+```tsx
+// In your payload.config.ts
+import { buildConfig } from 'payload/config'
+import { encryptedFieldsPlugin } from '@oversightstudio/encrypted-fields'
+
+export default buildConfig({
+  // Your Payload config
+  plugins: [
+    encryptedFieldsPlugin({
+      collections: ['users', 'customers', 'sensitive-data'],
+      // Optional: specify which field types to encrypt (defaults to all supported types)
+      fieldTypes: ['text', 'email', 'number'],
+      // Optional: fields to exclude from encryption
+      excludeFields: ['id', 'createdAt', 'updatedAt', 'username'],
+      // Optional: provide a custom secret key (falls back to process.env.PAYLOAD_SECRET)
+      secret: process.env.MY_CUSTOM_SECRET
+    })
+  ],
+})
+```
+
+### Field Mode
+
+For more granular control, you can wrap individual fields with the `encryptedField` function:
 
 ```tsx
 import { CollectionConfig } from 'payload'
@@ -63,6 +97,18 @@ export const SensitiveDataCollection: CollectionConfig = {
 }
 ```
 
+## Plugin Options
+
+The `encryptedFieldsPlugin` accepts the following options:
+
+| Option | Type | Description | Default |
+|--------|------|-------------|---------|
+| `enabled` | `boolean` | Enable or disable the plugin | `true` |
+| `collections` | `string[]` | Array of collection slugs to apply encryption to | `[]` |
+| `fieldTypes` | `string[]` | Field types to encrypt | All supported types |
+| `excludeFields` | `string[]` | Fields to exclude from encryption | `['id', 'createdAt', 'updatedAt']` |
+| `secret` | `string` | Secret key used for encryption | `process.env.PAYLOAD_SECRET` |
+
 ## Supported Field Types
 | Field Type   | Supported |
 |-------------|-----------|
@@ -79,7 +125,7 @@ export const SensitiveDataCollection: CollectionConfig = {
 | `point`     | ❌ Not yet supported |
 | `richText`  | ❌ Not yet supported |
 
-All other missing field types (like as `ui`, `tabs`, etc.) are of course **not supported**, as they do not store user data that needs encryption.  
+All other field types (like `ui`, `tabs`, etc.) are of course **not supported**, as they do not store user data that needs encryption. However, the plugin is smart enough to handle nested fields inside complex field types like `tabs`, `blocks`, `arrays`, and `groups`.
 
 ## Credits
 * Shoutout to [Paul](https://github.com/paulpopus) for being a real one.

--- a/packages/encrypted-fields/src/index.ts
+++ b/packages/encrypted-fields/src/index.ts
@@ -1,1 +1,107 @@
+import type { Config, CollectionConfig } from 'payload'
+import { encryptedField, EncryptedFieldOptions } from './fields/encryptedField'
+import { processCollection } from './utils/processCollection'
+
 export { encryptedField } from './fields/encryptedField'
+
+export interface EncryptedFieldsPluginOptions {
+  /**
+   * Enable or disable the plugin
+   * @default true
+   */
+  enabled?: boolean
+
+  /**
+   * Collections to encrypt fields in
+   * @example ['users', 'customers']
+   */
+  collections?: string[]
+
+  /**
+   * Field types to encrypt
+   * If not specified, all supported field types will be encrypted
+   * @example ['text', 'email']
+   */
+  fieldTypes?: Array<EncryptedFieldOptions['type']>
+
+  /**
+   * Field names to exclude from encryption
+   * @example ['id', 'createdAt', 'updatedAt']
+   */
+  excludeFields?: string[]
+
+  /**
+   * Secret key used for encryption
+   * If not specified, falls back to process.env.PAYLOAD_SECRET
+   * @example 'your-secret-key-here'
+   */
+  secret?: string
+}
+
+const defaultOptions: Partial<EncryptedFieldsPluginOptions> = {
+  enabled: true,
+  excludeFields: ['id', 'createdAt', 'updatedAt'],
+}
+
+const supportedFieldTypes: Array<EncryptedFieldOptions['type']> = [
+  'text',
+  'number',
+  'select',
+  'checkbox',
+  'email',
+  'date',
+  'json',
+  'textarea',
+  'code',
+  'radio',
+]
+
+export const encryptedFieldsPlugin =
+  (pluginOptions: EncryptedFieldsPluginOptions = {}) =>
+  (incomingConfig: Config): Config => {
+    const options = { ...defaultOptions, ...pluginOptions }
+
+    // If plugin is disabled, return unmodified config
+    if (options.enabled === false) {
+      return incomingConfig
+    }
+
+    // Create a copy of the config to modify
+    const config = { ...incomingConfig }
+
+    // Check for encryption secret - either from options or environment variable
+    const secret = options.secret || process.env.PAYLOAD_SECRET
+
+    // If no secret available, warn and return unmodified config
+    if (!secret) {
+      console.warn(
+        'WARNING: No encryption secret provided. Please set the secret option or PAYLOAD_SECRET environment variable. Encrypted fields will not work properly.',
+      )
+      return incomingConfig
+    }
+
+    // Store the secret in global context for the encryption/decryption utilities to use
+    global.PAYLOAD_ENCRYPTED_FIELDS_SECRET = secret
+
+    // If no collections specified, return unmodified config
+    if (!options.collections || options.collections.length === 0) {
+      return incomingConfig
+    }
+
+    // Use specified field types or all supported types
+    const fieldTypesToEncrypt = options.fieldTypes || supportedFieldTypes
+
+    // Process each collection
+    if (config.collections) {
+      config.collections = config.collections.map((collection) => {
+        // Skip collections not specified in options
+        if (!options.collections?.includes(collection.slug)) {
+          return collection
+        }
+
+        return processCollection(collection, fieldTypesToEncrypt, options.excludeFields || [])
+      })
+    }
+
+    return config
+  }

--- a/packages/encrypted-fields/src/utils/decrypt.ts
+++ b/packages/encrypted-fields/src/utils/decrypt.ts
@@ -3,12 +3,15 @@ import { createKeyFromSecret } from './encrypt'
 import { algorithm } from '../consts'
 
 export const decrypt = (hash: string): string => {
+  // Use global secret set by plugin or fall back to environment variable
+  const secret = global.PAYLOAD_ENCRYPTED_FIELDS_SECRET || process.env.PAYLOAD_SECRET!
+  
   const iv = hash.slice(0, 32)
   const content = hash.slice(32)
 
   const decipher = crypto.createDecipheriv(
     algorithm,
-    createKeyFromSecret(process.env.PAYLOAD_SECRET!),
+    createKeyFromSecret(secret),
     Buffer.from(iv, 'hex'),
   )
 

--- a/packages/encrypted-fields/src/utils/encrypt.ts
+++ b/packages/encrypted-fields/src/utils/encrypt.ts
@@ -1,14 +1,22 @@
 import crypto from 'crypto'
 import { algorithm } from '../consts'
 
+// Add global type definition
+declare global {
+  var PAYLOAD_ENCRYPTED_FIELDS_SECRET: string | undefined
+}
+
 export const createKeyFromSecret = (secretKey: string): string =>
   crypto.createHash('sha256').update(secretKey).digest('hex').slice(0, 32)
 
 export const encrypt = (text: string): string => {
+  // Use global secret set by plugin or fall back to environment variable
+  const secret = global.PAYLOAD_ENCRYPTED_FIELDS_SECRET || process.env.PAYLOAD_SECRET!
+  
   const iv = crypto.randomBytes(16)
   const cipher = crypto.createCipheriv(
     algorithm,
-    createKeyFromSecret(process.env.PAYLOAD_SECRET!),
+    createKeyFromSecret(secret),
     iv,
   )
 

--- a/packages/encrypted-fields/src/utils/processCollection.ts
+++ b/packages/encrypted-fields/src/utils/processCollection.ts
@@ -1,0 +1,24 @@
+import { CollectionConfig } from 'payload'
+import { EncryptedFieldOptions } from '../fields/encryptedField'
+import { processFields } from './processFields'
+
+/**
+ * Process a collection to encrypt specified field types
+ */
+export const processCollection = (
+  collection: CollectionConfig,
+  fieldTypesToEncrypt: Array<EncryptedFieldOptions['type']>,
+  excludeFields: string[],
+): CollectionConfig => {
+  const processedCollection = { ...collection }
+
+  if (processedCollection.fields) {
+    processedCollection.fields = processFields(
+      processedCollection.fields,
+      fieldTypesToEncrypt,
+      excludeFields,
+    )
+  }
+
+  return processedCollection
+}

--- a/packages/encrypted-fields/src/utils/processFields.ts
+++ b/packages/encrypted-fields/src/utils/processFields.ts
@@ -1,0 +1,52 @@
+import { encryptedField, EncryptedFieldOptions } from '../fields/encryptedField'
+
+/**
+ * Process fields recursively to encrypt applicable fields
+ */
+export const processFields = (
+  fields: any[],
+  fieldTypesToEncrypt: Array<EncryptedFieldOptions['type']>,
+  excludeFields: string[],
+): any[] => {
+  return fields.map((field) => {
+    if (field.type === 'tabs' && Array.isArray(field.tabs)) {
+      return {
+        ...field,
+        tabs: field.tabs.map((tab: any) => ({
+          ...tab,
+          fields: processFields(tab.fields, fieldTypesToEncrypt, excludeFields),
+        })),
+      }
+    }
+
+    if (
+      field.fields &&
+      (field.type === 'group' || field.type === 'array' || field.type === 'row')
+    ) {
+      return {
+        ...field,
+        fields: processFields(field.fields, fieldTypesToEncrypt, excludeFields),
+      }
+    }
+
+    if (field.type === 'blocks' && Array.isArray(field.blocks)) {
+      return {
+        ...field,
+        blocks: field.blocks.map((block: any) => ({
+          ...block,
+          fields: processFields(block.fields, fieldTypesToEncrypt, excludeFields),
+        })),
+      }
+    }
+
+    if (excludeFields.includes(field.name)) {
+      return field
+    }
+
+    if (field.name && field.type && fieldTypesToEncrypt.includes(field.type)) {
+      return encryptedField(field)
+    }
+
+    return field
+  })
+}


### PR DESCRIPTION
# Add Plugin Mode to Encrypted Fields

## Summary
This PR enhances the `encrypted-fields` package by adding a new plugin-based approach that simplifies field encryption across collections. It allows developers to automatically encrypt sensitive fields without manually wrapping each field.

## Changes
- Added new `encryptedFieldsPlugin` with configuration options:
  - `collections`: Specify which collections to apply encryption to
  - `fieldTypes`: Control which field types get encrypted
  - `excludeFields`: Skip specific fields from encryption
  - `secret`: Provide a custom encryption secret (falls back to PAYLOAD_SECRET)
- Created utility functions to recursively process collections and fields
- Enhanced encryption utilities to support custom secrets
- Improved support for complex field types (tabs, blocks, arrays, groups)
- Updated documentation with comprehensive examples and options table
- Added TypeScript types for better developer experience

## Benefits
- **Simplified Implementation**: Enable encryption across multiple collections with minimal code
- **Greater Flexibility**: Fine-tune which fields get encrypted
- **Backward Compatible**: Existing `encryptedField` function still works for granular control
- **Better Documentation**: Clearer setup instructions with examples

## Example Usage
```tsx
// In your payload.config.ts
import { buildConfig } from 'payload/config'
import { encryptedFieldsPlugin } from '@oversightstudio/encrypted-fields'

export default buildConfig({
  plugins: [
    encryptedFieldsPlugin({
      collections: ['users', 'customers', 'sensitive-data'],
      fieldTypes: ['text', 'email', 'number'],
      excludeFields: ['id', 'createdAt', 'updatedAt', 'username'],
      secret: process.env.MY_CUSTOM_SECRET
    })
  ],
})
```