### PR TITLE
docs(mux): add note about webhook API endpoint

### DIFF
--- a/packages/mux-video/README.md
+++ b/packages/mux-video/README.md
@@ -14,7 +14,9 @@ Features include:
 ![muxVideoPreview](/gifs/mux-preview.gif)
 
 ## Payload Setup
-There are two possible setups for this plugin: The public setup, andthe signed URLs setup. The main difference between the two is that the signed URLs setup requires setting up a little extra configuration, but that's about it.
+There are two possible setups for this plugin: The public setup, and the signed URLs setup. The main difference between the two is that the signed URLs setup requires setting up a little extra configuration, but that's about it.
+
+To get started, you’ll need to generate your MUX tokens and secrets from the MUX Dashboard. When configuring the webhook, set the URL to the automatically generated API endpoint provided by this plugin at `/api/mux/webhook`.
 
 ### Public Setup
 ```tsx
@@ -37,6 +39,8 @@ export default buildConfig({
   ],
 })
 ```
+
+
 
 ### Signed URLs Setup
 ```tsx


### PR DESCRIPTION
This PR adds a note about the webhook API endpoint path to the Mux plugin Setup guide.

Thanks for this plugin! 🖤