### PR TITLE
fix(mux): account for custom API endpoint set via `routes.api`

### DIFF
--- a/packages/mux-video/README.md
+++ b/packages/mux-video/README.md
@@ -16,7 +16,7 @@ Features include:
 ## Payload Setup
 There are two possible setups for this plugin: The public setup, and the signed URLs setup. The main difference between the two is that the signed URLs setup requires setting up a little extra configuration, but that's about it.
 
-To get started, you’ll need to generate your MUX tokens and secrets from the MUX Dashboard. When configuring the webhook, set the URL to the automatically generated API endpoint provided by this plugin at `/api/mux/webhook`.
+To get started, you’ll need to generate your MUX tokens and secrets from the MUX Dashboard. When configuring the webhook, set the URL to the automatically generated API endpoint provided by this plugin at `/api/mux/webhook`. If you have set a custom API route in Payload config via `routes.api`, the API endpoint will be `<your_custom_api_route>/mux/webhook`.
 
 ### Public Setup
 ```tsx

--- a/packages/mux-video/src/fields/mux-uploader/mux-uploader.tsx
+++ b/packages/mux-video/src/fields/mux-uploader/mux-uploader.tsx
@@ -3,11 +3,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import MuxPlayer from '@mux/mux-player-react'
 import MuxUploader from '@mux/mux-uploader-react'
-import { useForm, useFormFields } from '@payloadcms/ui'
+import { useConfig, useForm, useFormFields } from '@payloadcms/ui'
 import path from 'path'
 import './mux-uploader.scss'
 
 export const MuxUploaderField = () => {
+  const { config } = useConfig()
+  const apiUrl = config.routes.api
+
   const [uploadId, setUploadId] = useState('')
   const { assetId, setAssetId, title, setTitle, setFile, playbackUrl } = useFormFields(
     ([fields, dispatch]) => ({
@@ -28,7 +31,7 @@ export const MuxUploaderField = () => {
     console.log('get signed url')
 
     // Fetch the signed URL from the API
-    const response = await fetch(`/api/mux/upload`, {
+    const response = await fetch(`${apiUrl}/mux/upload`, {
       method: 'POST',
     })
 
@@ -75,7 +78,7 @@ export const MuxUploaderField = () => {
 
     /* When the upload succeeded, get the Asset ID from the server */
     let upload = await (
-      await fetch(`/api/mux/upload?id=${uploadId}`, {
+      await fetch(`${apiUrl}/mux/upload?id=${uploadId}`, {
         method: 'get',
       })
     ).json()
@@ -88,7 +91,7 @@ export const MuxUploaderField = () => {
       console.log(`Polling for asset_id...`)
       await new Promise((resolve) => setTimeout(resolve, 1000))
       upload = await (
-        await fetch(`/api/mux/upload?id=${uploadId}`, {
+        await fetch(`${apiUrl}/mux/upload?id=${uploadId}`, {
           method: 'get',
         })
       ).json()


### PR DESCRIPTION
Currently, the plugin doesn't respect a custom API endpoint defined in the Payload CMS config via `routes.api`. I've just updated the uploader to use the API route provided by `useConfig()`, and updated the docs for clarity.