### PR TITLE
Fix: Include posterTimestamp in JWT claims for signed playback URLs

### DIFF
--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -212,6 +212,7 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   const token = await mux.jwt.signPlaybackId(playbackId, {
                     expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
                     type: 'thumbnail',
+                    params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
                   })
 
                   url.searchParams.set('token', token)

--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -250,6 +250,7 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   const token = await mux.jwt.signPlaybackId(playbackId, {
                     expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
                     type: 'gif',
+					params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
                   })
 
                   url.searchParams.set('token', token)

--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -250,7 +250,7 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   const token = await mux.jwt.signPlaybackId(playbackId, {
                     expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
                     type: 'gif',
-					params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
+                    params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
                   })
 
                   url.searchParams.set('token', token)


### PR DESCRIPTION
- Add params object with time claim when signing thumbnail JWT
- Fixes issue #23 where posterTimestamp didn't affect signed URLs
- For signed policies, thumbnail options must be in JWT claims per Mux docs"