### PR TITLE
Mux Video 1.3

### DIFF
--- a/.changeset/mux-video-1.3.md
+++ b/.changeset/mux-video-1.3.md
@@ -1,5 +1,5 @@
 ---
-'@oversightstudio/mux-video': patch
+'@oversightstudio/mux-video': minor
 ---
 
 * **Fix**: Include posterTimestamp in JWT claims for signed thumbnail and GIF playback URLs

--- a/.changeset/mux-video-1.3.md
+++ b/.changeset/mux-video-1.3.md
@@ -1,5 +1,5 @@
 ---
-'@oversightstudio/mux-video': minor
+'@oversightstudio/mux-video': patch
 ---
 
 * **Fix**: Include posterTimestamp in JWT claims for signed thumbnail and GIF playback URLs

--- a/.changeset/mux-video-1.3.md
+++ b/.changeset/mux-video-1.3.md
@@ -1,0 +1,6 @@
+---
+'@oversightstudio/mux-video': minor
+---
+
+* **Fix**: Include posterTimestamp in JWT claims for signed thumbnail and GIF playback URLs
+* **Feature**: Add support for configurable file extensions for poster images and animated previews

--- a/packages/mux-video/README.md
+++ b/packages/mux-video/README.md
@@ -79,6 +79,8 @@ export default buildConfig({
 | `extendCollection`         | `string`                                         | *Optional* | The slug of an existing collection to extend with Mux video functionality. |
 | `access`                   | `(request: PayloadRequest) => Promise<boolean> \| boolean` | *Optional* | An optional function to determine who can upload files. Should return a boolean or a Promise resolving to a boolean. |
 | `signedUrlOptions`         | `MuxVideoSignedUrlOptions`                       | *Optional* | Options for signed URL generation.                                                                     |
+| `posterExtension`          | `'webp' \| 'jpg' \| 'png'`                       | `"png"`  | The image format to use for video posters. |
+| `animatedGifExtension`     | `'gif' \| 'webp'`                                | `"gif"`  | The image format to use for animated preview thumbnails. |
 | `adminThumbnail`           | `'gif' \| 'image' \| 'none'`                     | `"gif"`  | Specifies the type of thumbnail to display for videos in the collection list view. |
 
 ### `initSettings` Options 

--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -212,6 +212,7 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   const token = await mux.jwt.signPlaybackId(playbackId, {
                     expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
                     type: 'thumbnail',
+                    params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
                   })
 
                   url.searchParams.set('token', token)

--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -250,6 +250,7 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   const token = await mux.jwt.signPlaybackId(playbackId, {
                     expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
                     type: 'gif',
+					params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
                   })
 
                   url.searchParams.set('token', token)

--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -250,7 +250,7 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   const token = await mux.jwt.signPlaybackId(playbackId, {
                     expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
                     type: 'gif',
-					params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
+                    params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
                   })
 
                   url.searchParams.set('token', token)

--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -202,7 +202,9 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   return null
                 }
 
-                const url = new URL(`https://image.mux.com/${playbackId}/thumbnail.png`)
+                const extension = pluginOptions.posterExtension ?? 'png'
+
+                const url = new URL(`https://image.mux.com/${playbackId}/thumbnail.${extension}`)
 
                 if (typeof posterTimestamp === 'number') {
                   url.searchParams.set('time', posterTimestamp.toString())
@@ -240,7 +242,9 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   return null
                 }
 
-                const url = new URL(`https://image.mux.com/${playbackId}/animated.gif`)
+                const extension = pluginOptions.animatedGifExtension ?? 'gif'
+
+                const url = new URL(`https://image.mux.com/${playbackId}/animated.${extension}`)
 
                 if (typeof posterTimestamp === 'number') {
                   url.searchParams.set('time', posterTimestamp.toString())

--- a/packages/mux-video/src/types.ts
+++ b/packages/mux-video/src/types.ts
@@ -108,6 +108,20 @@ export type MuxVideoPluginOptions = {
   uploadSettings: MuxVideoUploadSettings
 
   /**
+   * The image format to use for video posters.
+   * 
+   * @default "png"
+   */
+  posterExtension?: 'webp' | 'jpg' | 'png'
+
+  /**
+   * The image format to use for animated GIF previews.
+   * 
+   * @default "gif"
+   */
+  animatedGifExtension?: 'gif' | 'webp'
+
+  /**
    * An optional function to determine whether the current request is allowed to upload files.
    * Should return a boolean or a Promise resolving to a boolean.
    */


### PR DESCRIPTION
## Summary
- **Fix**: Include `posterTimestamp` in JWT claims for signed thumbnail and GIF playback URLs (#24)
- **Feature**: Add configurable file extensions for poster images and animated previews (#25)

## Changes
- Merges #24 and #25
- Adds changeset for minor version bump (`@oversightstudio/mux-video` 1.2.0 → 1.3.0)

Closes #23