### PR TITLE
feat(mux-video): add option to create missing videos in Payload

### DIFF
--- a/.changeset/silly-buses-unite.md
+++ b/.changeset/silly-buses-unite.md
@@ -1,0 +1,5 @@
+---
+'@oversightstudio/mux-video': minor
+---
+
+Feature: Add `autoCreateOnWebhook` option to automatically create videos that are missing from Payload collection

--- a/packages/mux-video/README.md
+++ b/packages/mux-video/README.md
@@ -82,6 +82,8 @@ export default buildConfig({
 | `posterExtension`          | `'webp' \| 'jpg' \| 'png'`                       | `"png"`  | The image format to use for video posters. |
 | `animatedGifExtension`     | `'gif' \| 'webp'`                                | `"gif"`  | The image format to use for animated preview thumbnails. |
 | `adminThumbnail`           | `'gif' \| 'image' \| 'none'`                     | `"gif"`  | Specifies the type of thumbnail to display for videos in the collection list view. |
+| `autoCreateOnWebhook`    | `boolean`                                        | `false`  | If enabled, the Mux webhook will automatically create videos that are missing in Payload when webhooks are received from Mux. Useful for uploading videos directly in Mux and automatically backfilling them in Payload. |
+
 
 ### `initSettings` Options 
 

--- a/packages/mux-video/src/endpoints/webhook.ts
+++ b/packages/mux-video/src/endpoints/webhook.ts
@@ -44,8 +44,27 @@ export const muxWebhooksHandler =
 
     const video = videos.totalDocs > 0 ? videos.docs[0] : null
 
-    // TODO: Maybe find a better way to handle this?
     if (!video) {
+      if (
+        pluginOptions.autoCreateOnWebhook &&
+        (event.type === 'video.asset.created' ||
+          event.type === 'video.asset.ready' ||
+          event.type === 'video.asset.updated')
+      ) {
+        try {
+          await req.payload.create({
+            collection,
+            data: {
+              title: event.data.meta?.title || assetId,
+              assetId,
+              ...getAssetMetadata(event.data),
+            },
+          })
+        } catch (err) {
+          return createErrorResponse()
+        }
+      }
+
       return createSuccessResponse()
     }
 

--- a/packages/mux-video/src/types.ts
+++ b/packages/mux-video/src/types.ts
@@ -109,14 +109,14 @@ export type MuxVideoPluginOptions = {
 
   /**
    * The image format to use for video posters.
-   * 
+   *
    * @default "png"
    */
   posterExtension?: 'webp' | 'jpg' | 'png'
 
   /**
    * The image format to use for animated GIF previews.
-   * 
+   *
    * @default "gif"
    */
   animatedGifExtension?: 'gif' | 'webp'
@@ -131,4 +131,14 @@ export type MuxVideoPluginOptions = {
    * Options for generating signed URLs for video playback.
    */
   signedUrlOptions?: MuxVideoSignedUrlOptions
+
+  /**
+   * When enabled, the webhook will automatically create a video in Payload
+   * when it receives a `video.asset.created`, `video.asset.ready`, or
+   * `video.asset.updated` event from Mux for an asset that doesn't exist
+   * in Payload.
+   *
+   * @default false
+   */
+  autoCreateOnWebhook?: boolean
 }


### PR DESCRIPTION
### What

Currently, the webook handler silently drops webhooks for videos that don't exist in Payload. This PR adds a `autoCreateOnWebhook` option that when set to `true` will make the webhook handler create non-existant videos in Payload for the `video.asset.created`, `video.asset.ready` and `video.asset.updated` events. It will pull the title of the video from Mux if set.

### Why

We have a project where editors need to upload videos directly from the Mux dashboard without going through Payload. Without this option, videos created directly in Mux would never be available for selection in Payload.