### PR TITLE
fix: mux plugin fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "oversightstudio-plugins",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "dev": "cd dev && pnpm dev",
-    "build": "pnpm --filter=./packages/* run build",
-    "release": "pnpm --filter=./packages/* publish --access public"
-  },
-  "keywords": [],
-  "author": "oversightstudio",
-  "license": "MIT",
-  "pnpm": {
-    "overrides": {
-      "minimatch@<3.1.3": "3.1.3",
-      "minimatch@>=9.0.0 <9.0.7": "9.0.7"
-    }
-  },
-  "devDependencies": {
-    "@changesets/cli": "^2.27.12",
-    "prettier": "^3.5.2"
-  }
+	"name": "@oak-digital/mux-plugin",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"scripts": {
+		"dev": "cd dev && pnpm dev",
+		"build": "pnpm --filter=./packages/* run build",
+		"release": "pnpm --filter=./packages/* publish --access public"
+	},
+	"keywords": [],
+	"author": "oversightstudio & oakdigital",
+	"license": "MIT",
+	"pnpm": {
+		"overrides": {
+			"minimatch@<3.1.3": "3.1.3",
+			"minimatch@>=9.0.0 <9.0.7": "9.0.7"
+		}
+	},
+	"devDependencies": {
+		"@changesets/cli": "^2.27.12",
+		"prettier": "^3.5.2"
+	}
 }

--- a/packages/mux-video/LICENSE
+++ b/packages/mux-video/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 OVERSIGHT STUDIO LIMITED
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -1,74 +1,74 @@
 {
-  "name": "@oversightstudio/mux-video",
-  "type": "module",
-  "version": "1.4.0",
-  "description": "Brings Mux Video to PayloadCMS.",
-  "private": false,
-  "bugs": "https://github.com/oversightstudio/payload-plugins/issues",
-  "repository": "https://github.com/oversightstudio/payload-plugins/tree/main/packages/mux-video",
-  "license": "MIT",
-  "types": "./src/index.ts",
-  "main": "./src/index.ts",
-  "author": "oversightstudio",
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "payload",
-    "cms",
-    "plugin",
-    "mux",
-    "video",
-    "upload"
-  ],
-  "scripts": {
-    "build": "tsup"
-  },
-  "exports": {
-    ".": {
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
-    },
-    "./elements": {
-      "import": "./src/fields/index.ts",
-      "default": "./src/fields/index.ts"
-    }
-  },
-  "devDependencies": {
-    "@mux/mux-player-react": "^3.4.1",
-    "@payloadcms/ui": "^3.43.0",
-    "@types/react": "^19.1.8",
-    "esbuild-plugin-preserve-directives": "^0.0.11",
-    "payload": "^3.43.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "tsup": "^8.3.6",
-    "typescript": "^5.8.3"
-  },
-  "peerDependencies": {
-    "@mux/mux-player-react": "^3.4.1",
-    "@payloadcms/ui": "^3.43.0",
-    "payload": "^3.43.0"
-  },
-  "dependencies": {
-    "@mux/mux-node": "^11.1.0",
-    "@mux/mux-uploader-react": "^1.2.0"
-  },
-  "publishConfig": {
-    "exports": {
-      ".": {
-        "import": "./dist/index.js",
-        "require": "./dist/index.js",
-        "types": "./dist/index.d.ts"
-      },
-      "./elements": {
-        "import": "./dist/fields/index.js",
-        "require": "./dist/fields/index.js",
-        "types": "./dist/fields/index.d.ts"
-      }
-    },
-    "main": "./dist/index.js",
-    "registry": "https://registry.npmjs.org/",
-    "types": "./dist/index.d.ts"
-  }
+	"name": "@oak-digital/mux-video",
+	"type": "module",
+	"version": "1.4.0",
+	"description": "Brings Mux Video to PayloadCMS.",
+	"private": false,
+	"bugs": "https://github.com/oversightstudio/payload-plugins/issues",
+	"repository": "https://github.com/oversightstudio/payload-plugins/tree/main/packages/mux-video",
+	"license": "MIT",
+	"types": "./src/index.ts",
+	"main": "./src/index.ts",
+	"author": "oversightstudio & oakdigital",
+	"files": [
+		"dist"
+	],
+	"keywords": [
+		"payload",
+		"cms",
+		"plugin",
+		"mux",
+		"video",
+		"upload"
+	],
+	"scripts": {
+		"build": "tsup"
+	},
+	"exports": {
+		".": {
+			"import": "./src/index.ts",
+			"default": "./src/index.ts"
+		},
+		"./elements": {
+			"import": "./src/fields/index.ts",
+			"default": "./src/fields/index.ts"
+		}
+	},
+	"devDependencies": {
+		"@mux/mux-player-react": "^3.4.1",
+		"@payloadcms/ui": "^3.43.0",
+		"@types/react": "^19.1.8",
+		"esbuild-plugin-preserve-directives": "^0.0.11",
+		"payload": "^3.43.0",
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0",
+		"tsup": "^8.3.6",
+		"typescript": "^5.8.3"
+	},
+	"peerDependencies": {
+		"@mux/mux-player-react": "^3.4.1",
+		"@payloadcms/ui": "^3.43.0",
+		"payload": "^3.43.0"
+	},
+	"dependencies": {
+		"@mux/mux-node": "^11.1.0",
+		"@mux/mux-uploader-react": "^1.2.0"
+	},
+	"publishConfig": {
+		"exports": {
+			".": {
+				"import": "./dist/index.js",
+				"require": "./dist/index.js",
+				"types": "./dist/index.d.ts"
+			},
+			"./elements": {
+				"import": "./dist/fields/index.js",
+				"require": "./dist/fields/index.js",
+				"types": "./dist/fields/index.d.ts"
+			}
+		},
+		"main": "./dist/index.js",
+		"registry": "https://registry.npmjs.org/",
+		"types": "./dist/index.d.ts"
+	}
 }

--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -1,272 +1,303 @@
-import { CollectionConfig } from 'payload'
-import getAfterDeleteMuxVideoHook from '../hooks/afterDelete'
-import getBeforeChangeMuxVideoHook from '../hooks/beforeChange'
-import Mux from '@mux/mux-node'
-import { MuxVideoPluginOptions } from '../types'
-import { defaultAccessFunction } from '../lib/defaultAccessFunction'
+import type Mux from "@mux/mux-node";
+import type { CollectionConfig } from "payload";
+import getAfterDeleteMuxVideoHook from "../hooks/afterDelete";
+import getAfterReadMuxVideoHook from "../hooks/afterRead";
+import getBeforeChangeMuxVideoHook from "../hooks/beforeChange";
+import { defaultAccessFunction } from "../lib/defaultAccessFunction";
+import type { MuxVideoPluginOptions } from "../types";
 
-export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): CollectionConfig => ({
-  slug: (pluginOptions.extendCollection as string) ?? 'mux-video',
-  labels: {
-    singular: 'Video',
-    plural: 'Videos',
-  },
-  access: {
-    read: ({ req }) => pluginOptions.access?.(req) ?? defaultAccessFunction(req),
-  },
-  admin: {
-    useAsTitle: 'title',
-    defaultColumns: ['title', 'muxUploader', 'duration'],
-  },
-  hooks: {
-    afterDelete: [getAfterDeleteMuxVideoHook(mux)],
-    beforeChange: [
-      getBeforeChangeMuxVideoHook(mux, (pluginOptions.extendCollection as string) ?? 'mux-video'),
-    ],
-  },
-  fields: [
-    {
-      name: 'muxUploader',
-      label: 'Video Preview',
-      type: 'ui',
-      admin: {
-        components: {
-          Field: '@oversightstudio/mux-video/elements#MuxUploaderField',
-          Cell:
-            pluginOptions.adminThumbnail === 'gif'
-              ? '@oversightstudio/mux-video/elements#MuxVideoGifCell'
-              : pluginOptions.adminThumbnail === 'image'
-                ? '@oversightstudio/mux-video/elements#MuxVideoImageCell'
-                : undefined,
-        },
-      },
-    },
-    {
-      name: 'title',
-      type: 'text',
-      label: 'Title',
-      required: true,
-      unique: true,
-      admin: {
-        description: `A unique title for this video that will help you identify it later.`,
-      },
-    },
-    {
-      name: 'assetId',
-      type: 'text',
-      required: true,
-      admin: {
-        readOnly: true,
-        condition: (data) => data.assetId,
-      },
-    },
-    {
-      name: 'duration',
-      label: 'Duration',
-      type: 'number',
-      admin: {
-        readOnly: true,
-        condition: (data) => data.duration,
-      },
-    },
-    {
-      name: 'posterTimestamp',
-      type: 'number',
-      label: 'Poster Timestamp',
-      min: 0,
-      admin: {
-        description:
-          'Pick a timestamp (in seconds) from the video to be used as the poster image. When unset, defaults to the middle of the video.',
-        // Only show it when playbackId has been set, so users can pick the poster image using the player
-        condition: (data) => data.duration,
-        step: 0.25,
-      },
-      validate: (value: any, { siblingData }: any) => {
-        if (!siblingData.duration || !value) {
-          return true
-        }
+export const MuxVideo = (
+	mux: Mux,
+	pluginOptions: MuxVideoPluginOptions,
+): CollectionConfig => ({
+	slug: (pluginOptions.extendCollection as string) ?? "mux-video",
+	labels: {
+		singular: "Video",
+		plural: "Videos",
+	},
+	access: {
+		read: ({ req }) =>
+			pluginOptions.access?.(req) ?? defaultAccessFunction(req),
+	},
+	folders: true,
+	admin: {
+		useAsTitle: "title",
+		group: "Assets",
+		defaultColumns: ["title", "muxUploader", "duration"],
+	},
+	hooks: {
+		afterRead: [
+			getAfterReadMuxVideoHook(
+				mux,
+				(pluginOptions.extendCollection as string) ?? "mux-video",
+			),
+		],
+		afterDelete: [getAfterDeleteMuxVideoHook(mux)],
+		beforeChange: [
+			getBeforeChangeMuxVideoHook(
+				mux,
+				(pluginOptions.extendCollection as string) ?? "mux-video",
+			),
+		],
+	},
+	fields: [
+		{
+			name: "muxUploader",
+			label: "Video Preview",
+			type: "ui",
+			admin: {
+				components: {
+					Field: "@oversightstudio/mux-video/elements#MuxUploaderField",
+					Cell:
+						pluginOptions.adminThumbnail === "gif"
+							? "@oversightstudio/mux-video/elements#MuxVideoGifCell"
+							: pluginOptions.adminThumbnail === "image"
+								? "@oversightstudio/mux-video/elements#MuxVideoImageCell"
+								: undefined,
+				},
+			},
+		},
+		{
+			name: "title",
+			type: "text",
+			label: "Title",
+			required: true,
+			unique: true,
+			admin: {
+				description: `A unique title for this video that will help you identify it later.`,
+			},
+		},
+		{
+			name: "assetId",
+			type: "text",
+			required: true,
+			admin: {
+				readOnly: true,
+				condition: (data) => data.assetId,
+			},
+		},
+		{
+			name: "duration",
+			label: "Duration",
+			type: "number",
+			admin: {
+				readOnly: true,
+				condition: (data) => data.duration,
+			},
+		},
+		{
+			name: "posterTimestamp",
+			type: "number",
+			label: "Poster Timestamp",
+			min: 0,
+			admin: {
+				description:
+					"Pick a timestamp (in seconds) from the video to be used as the poster image. When unset, defaults to the middle of the video.",
+				// Only show it when playbackId has been set, so users can pick the poster image using the player
+				condition: (data) => data.duration,
+				step: 0.25,
+			},
+			validate: (value: any, { siblingData }: any) => {
+				if (!siblingData.duration || !value) {
+					return true;
+				}
 
-        return (
-          Boolean(siblingData.duration >= value) ||
-          'Poster timestamp must be less than the video duration.'
-        )
-      },
-    },
-    {
-      name: 'aspectRatio',
-      label: 'Aspect Ratio',
-      type: 'text',
-      admin: {
-        readOnly: true,
-        condition: (data) => data.aspectRatio,
-      },
-    },
-    {
-      name: 'maxWidth',
-      type: 'number',
-      admin: {
-        readOnly: true,
-        condition: (data) => data.maxWidth,
-      },
-    },
-    {
-      name: 'maxHeight',
-      type: 'number',
-      admin: {
-        readOnly: true,
-        condition: (data) => data.maxHeight,
-      },
-    },
-    {
-      name: 'playbackOptions',
-      type: 'array',
-      admin: {
-        readOnly: true,
-        condition: (data) => !!data.playbackOptions,
-      },
-      fields: [
-        {
-          name: 'playbackId',
-          label: 'Playback ID',
-          type: 'text',
-          admin: {
-            readOnly: true,
-          },
-        },
-        {
-          name: 'playbackPolicy',
-          label: 'Playback Policy',
-          type: 'select',
-          options: [
-            {
-              label: 'signed',
-              value: 'signed',
-            },
-            {
-              label: 'public',
-              value: 'public',
-            },
-          ],
-          admin: {
-            readOnly: true,
-          },
-        },
-        {
-          name: 'playbackUrl',
-          label: 'Playback URL',
-          type: 'text',
-          virtual: true,
-          admin: {
-            hidden: true,
-          },
-          hooks: {
-            afterRead: [
-              async ({ siblingData }) => {
-                const playbackId = siblingData?.['playbackId']
+				return (
+					Boolean(siblingData.duration >= value) ||
+					"Poster timestamp must be less than the video duration."
+				);
+			},
+		},
+		{
+			name: "aspectRatio",
+			label: "Aspect Ratio",
+			type: "text",
+			admin: {
+				readOnly: true,
+				condition: (data) => data.aspectRatio,
+			},
+		},
+		{
+			name: "maxWidth",
+			type: "number",
+			admin: {
+				readOnly: true,
+				condition: (data) => data.maxWidth,
+			},
+		},
+		{
+			name: "maxHeight",
+			type: "number",
+			admin: {
+				readOnly: true,
+				condition: (data) => data.maxHeight,
+			},
+		},
+		{
+			name: "playbackOptions",
+			type: "array",
+			admin: {
+				readOnly: true,
+				condition: (data) => !!data.playbackOptions,
+			},
+			fields: [
+				{
+					name: "playbackId",
+					label: "Playback ID",
+					type: "text",
+					admin: {
+						readOnly: true,
+					},
+				},
+				{
+					name: "playbackPolicy",
+					label: "Playback Policy",
+					type: "select",
+					options: [
+						{
+							label: "signed",
+							value: "signed",
+						},
+						{
+							label: "public",
+							value: "public",
+						},
+					],
+					admin: {
+						readOnly: true,
+					},
+				},
+				{
+					name: "playbackUrl",
+					label: "Playback URL",
+					type: "text",
+					virtual: true,
+					admin: {
+						hidden: true,
+					},
+					hooks: {
+						afterRead: [
+							async ({ siblingData }) => {
+								const playbackId = siblingData?.["playbackId"];
 
-                if (!playbackId) {
-                  return null
-                }
+								if (!playbackId) {
+									return null;
+								}
 
-                const url = new URL(`https://stream.mux.com/${playbackId}.m3u8`)
+								const url = new URL(
+									`https://stream.mux.com/${playbackId}.m3u8`,
+								);
 
-                if (siblingData.playbackPolicy === 'signed') {
-                  const token = await mux.jwt.signPlaybackId(playbackId, {
-                    expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
-                    type: 'video',
-                  })
+								if (siblingData.playbackPolicy === "signed") {
+									const token = await mux.jwt.signPlaybackId(playbackId, {
+										expiration:
+											pluginOptions.signedUrlOptions?.expiration ?? "1d",
+										type: "video",
+									});
 
-                  url.searchParams.set('token', token)
-                }
+									url.searchParams.set("token", token);
+								}
 
-                return url.toString()
-              },
-            ],
-          },
-        },
-        {
-          name: 'posterUrl',
-          label: 'Poster URL',
-          type: 'text',
-          virtual: true,
-          admin: {
-            hidden: true,
-          },
-          hooks: {
-            afterRead: [
-              async ({ data, siblingData }) => {
-                const playbackId = siblingData?.['playbackId']
-                const posterTimestamp = data?.['posterTimestamp']
+								return url.toString();
+							},
+						],
+					},
+				},
+				{
+					name: "posterUrl",
+					label: "Poster URL",
+					type: "text",
+					virtual: true,
+					admin: {
+						hidden: true,
+					},
+					hooks: {
+						afterRead: [
+							async ({ data, siblingData }) => {
+								const playbackId = siblingData?.["playbackId"];
+								const posterTimestamp = data?.["posterTimestamp"];
 
-                if (!playbackId) {
-                  return null
-                }
+								if (!playbackId) {
+									return null;
+								}
 
-                const extension = pluginOptions.posterExtension ?? 'png'
+								const extension = pluginOptions.posterExtension ?? "png";
 
-                const url = new URL(`https://image.mux.com/${playbackId}/thumbnail.${extension}`)
+								const url = new URL(
+									`https://image.mux.com/${playbackId}/thumbnail.${extension}`,
+								);
 
-                if (typeof posterTimestamp === 'number') {
-                  url.searchParams.set('time', posterTimestamp.toString())
-                }
+								if (typeof posterTimestamp === "number") {
+									url.searchParams.set("time", posterTimestamp.toString());
+								}
 
-                if (siblingData.playbackPolicy === 'signed') {
-                  const token = await mux.jwt.signPlaybackId(playbackId, {
-                    expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
-                    type: 'thumbnail',
-                    params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
-                  })
+								if (siblingData.playbackPolicy === "signed") {
+									const token = await mux.jwt.signPlaybackId(playbackId, {
+										expiration:
+											pluginOptions.signedUrlOptions?.expiration ?? "1d",
+										type: "thumbnail",
+										params:
+											typeof posterTimestamp === "number"
+												? { time: posterTimestamp.toString() }
+												: undefined,
+									});
 
-                  url.searchParams.set('token', token)
-                }
+									url.searchParams.set("token", token);
+								}
 
-                return url.toString()
-              },
-            ],
-          },
-        },
-        {
-          name: 'gifUrl',
-          label: 'Gif URL',
-          type: 'text',
-          virtual: true,
-          admin: {
-            hidden: true,
-          },
-          hooks: {
-            afterRead: [
-              async ({ data, siblingData }) => {
-                const playbackId = siblingData?.['playbackId']
-                const posterTimestamp = data?.['posterTimestamp']
+								return url.toString();
+							},
+						],
+					},
+				},
+				{
+					name: "gifUrl",
+					label: "Gif URL",
+					type: "text",
+					virtual: true,
+					admin: {
+						hidden: true,
+					},
+					hooks: {
+						afterRead: [
+							async ({ data, siblingData }) => {
+								const playbackId = siblingData?.["playbackId"];
+								const posterTimestamp = data?.["posterTimestamp"];
 
-                if (!playbackId) {
-                  return null
-                }
+								if (!playbackId) {
+									return null;
+								}
 
-                const extension = pluginOptions.animatedGifExtension ?? 'gif'
+								const extension = pluginOptions.animatedGifExtension ?? "gif";
 
-                const url = new URL(`https://image.mux.com/${playbackId}/animated.${extension}`)
+								const url = new URL(
+									`https://image.mux.com/${playbackId}/animated.${extension}`,
+								);
 
-                if (typeof posterTimestamp === 'number') {
-                  url.searchParams.set('time', posterTimestamp.toString())
-                }
+								if (typeof posterTimestamp === "number") {
+									url.searchParams.set("time", posterTimestamp.toString());
+								}
 
-                if (siblingData.playbackPolicy === 'signed') {
-                  const token = await mux.jwt.signPlaybackId(playbackId, {
-                    expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
-                    type: 'gif',
-                    params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
-                  })
+								if (siblingData.playbackPolicy === "signed") {
+									const token = await mux.jwt.signPlaybackId(playbackId, {
+										expiration:
+											pluginOptions.signedUrlOptions?.expiration ?? "1d",
+										type: "gif",
+										params:
+											typeof posterTimestamp === "number"
+												? { time: posterTimestamp.toString() }
+												: undefined,
+									});
 
-                  url.searchParams.set('token', token)
-                }
+									url.searchParams.set("token", token);
+								}
 
-                return url.toString()
-              },
-            ],
-          },
-        },
-      ],
-    },
-  ],
-})
+								return url.toString();
+							},
+						],
+					},
+				},
+			],
+		},
+	],
+});

--- a/packages/mux-video/src/endpoints/webhook.ts
+++ b/packages/mux-video/src/endpoints/webhook.ts
@@ -1,112 +1,139 @@
-import { PayloadHandler } from 'payload'
-import { getAssetMetadata } from '../lib/getAssetMetadata'
-import Mux from '@mux/mux-node'
-import { MuxVideoPluginOptions } from '../types'
+import type Mux from "@mux/mux-node";
+import type { PayloadHandler } from "payload";
+import { getAssetMetadata } from "../lib/getAssetMetadata";
+import type { MuxVideoPluginOptions } from "../types";
 
 const handleAssetErrored = (req: any, assetId: string, errors: any) => {
-  req.payload.logger.error(`[payload-mux] Error with assetId: ${assetId}`)
-  req.payload.logger.error(JSON.stringify(errors, null, 2))
-}
+	req.payload.logger.error(`[payload-mux] Error with assetId: ${assetId}`);
+	req.payload.logger.error(JSON.stringify(errors, null, 2));
+};
 
-const createSuccessResponse = () => new Response('Success!', { status: 200 })
-const createErrorResponse = () => new Response('Error', { status: 204 })
+const createSuccessResponse = () => new Response("Success!", { status: 200 });
+const createErrorResponse = () => new Response("Error", { status: 500 });
 
 export const muxWebhooksHandler =
-  (mux: Mux, pluginOptions: MuxVideoPluginOptions): PayloadHandler =>
-  async (req) => {
-    if (!req.json) {
-      return Response.error()
-    }
+	(mux: Mux, pluginOptions: MuxVideoPluginOptions): PayloadHandler =>
+	async (req) => {
+		if (!req.text) {
+			return new Response("Invalid request", { status: 400 });
+		}
 
-    const body = await req.json()
+		let event: any;
 
-    if (!body) {
-      return Response.error()
-    }
+		try {
+			const rawBody = await req.text();
+			mux.webhooks.verifySignature(rawBody, req.headers);
+			event = JSON.parse(rawBody);
+		} catch (err) {
+			req.payload.logger.error("[payload-mux] Invalid Mux webhook request:");
+			req.payload.logger.error(err);
+			return new Response("Invalid Mux webhook request", { status: 400 });
+		}
 
-    mux.webhooks.verifySignature(JSON.stringify(body), req.headers)
+		if (!event) {
+			return new Response("Invalid Mux webhook payload", { status: 400 });
+		}
 
-    const collection = (pluginOptions.extendCollection as string) ?? 'mux-video'
+		const collection =
+			(pluginOptions.extendCollection as string) ?? "mux-video";
 
-    const event = body
-    const assetId = event.object?.id
+		const assetId = event.object?.id ?? event.data?.id;
 
-    const videos = await req.payload.find({
-      collection,
-      where: {
-        assetId: {
-          equals: assetId,
-        },
-      },
-      limit: 1,
-      pagination: false,
-    })
+		if (!assetId) {
+			return createSuccessResponse();
+		}
 
-    const video = videos.totalDocs > 0 ? videos.docs[0] : null
+		const videos = await req.payload.find({
+			collection,
+			where: {
+				assetId: {
+					equals: assetId,
+				},
+			},
+			limit: 1,
+			pagination: false,
+		});
 
-    if (!video) {
-      if (
-        pluginOptions.autoCreateOnWebhook &&
-        (event.type === 'video.asset.created' ||
-          event.type === 'video.asset.ready' ||
-          event.type === 'video.asset.updated')
-      ) {
-        try {
-          await req.payload.create({
-            collection,
-            data: {
-              title: event.data.meta?.title || assetId,
-              assetId,
-              ...getAssetMetadata(event.data),
-            },
-          })
-        } catch (err) {
-          return createErrorResponse()
-        }
-      }
+		const video = videos.totalDocs > 0 ? videos.docs[0] : null;
 
-      return createSuccessResponse()
-    }
+		if (!video) {
+			if (
+				pluginOptions.autoCreateOnWebhook &&
+				(event.type === "video.asset.created" ||
+					event.type === "video.asset.ready" ||
+					event.type === "video.asset.updated")
+			) {
+				try {
+					await req.payload.create({
+						collection,
+						data: {
+							title: event.data.meta?.title || assetId,
+							assetId,
+							...getAssetMetadata(event.data),
+						},
+						overrideAccess: true,
+					});
+				} catch (err) {
+					req.payload.logger.error(
+						`[payload-mux] There was an error while creating video for asset ${assetId}:`,
+					);
+					req.payload.logger.error(err);
+					return createErrorResponse();
+				}
+			}
 
-    switch (event.type) {
-      case 'video.asset.ready':
-      case 'video.asset.updated': {
-        try {
-          await req.payload.update({
-            collection,
-            id: video.id,
-            data: {
-              ...getAssetMetadata(event.data),
-            },
-          })
-        } catch (err) {
-          return createErrorResponse()
-        }
-        break
-      }
+			return createSuccessResponse();
+		}
 
-      case 'video.asset.deleted': {
-        try {
-          await req.payload.delete({
-            collection,
-            id: video.id,
-          })
-        } catch (err) {
-          return createErrorResponse()
-        }
-        break
-      }
+		switch (event.type) {
+			case "video.asset.ready":
+			case "video.asset.updated": {
+				try {
+					await req.payload.update({
+						collection,
+						id: video.id,
+						data: {
+							...getAssetMetadata(event.data),
+						},
+						overrideAccess: true,
+					});
+				} catch (err) {
+					req.payload.logger.error(
+						`[payload-mux] There was an error while updating video for asset ${assetId}:`,
+					);
+					req.payload.logger.error(err);
+					return createErrorResponse();
+				}
+				break;
+			}
 
-      case 'video.asset.errored': {
-        if (event.data?.errors) {
-          handleAssetErrored(req, assetId, event.data.errors)
-        }
-        break
-      }
+			case "video.asset.deleted": {
+				try {
+					await req.payload.delete({
+						collection,
+						id: video.id,
+						overrideAccess: true,
+					});
+				} catch (err) {
+					req.payload.logger.error(
+						`[payload-mux] There was an error while deleting video for asset ${assetId}:`,
+					);
+					req.payload.logger.error(err);
+					return createErrorResponse();
+				}
+				break;
+			}
 
-      default:
-        break
-    }
+			case "video.asset.errored": {
+				if (event.data?.errors) {
+					handleAssetErrored(req, assetId, event.data.errors);
+				}
+				break;
+			}
 
-    return createSuccessResponse()
-  }
+			default:
+				break;
+		}
+
+		return createSuccessResponse();
+	};

--- a/packages/mux-video/src/fields/mux-uploader/mux-uploader.tsx
+++ b/packages/mux-video/src/fields/mux-uploader/mux-uploader.tsx
@@ -1,137 +1,210 @@
-'use client'
+"use client";
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import MuxPlayer from '@mux/mux-player-react'
-import MuxUploader from '@mux/mux-uploader-react'
-import { useConfig, useForm, useFormFields } from '@payloadcms/ui'
-import path from 'path'
-import './mux-uploader.scss'
+import MuxPlayer from "@mux/mux-player-react";
+import MuxUploader from "@mux/mux-uploader-react";
+import {
+	useConfig,
+	useDocumentInfo,
+	useForm,
+	useFormFields,
+} from "@payloadcms/ui";
+import path from "path";
+import { useCallback, useEffect, useRef, useState } from "react";
+import "./mux-uploader.scss";
+
+const ENCODING_POLL_INTERVAL = 5000;
+const ENCODING_POLL_LIMIT = 36;
 
 export const MuxUploaderField = () => {
-  const { config } = useConfig()
-  const apiUrl = config.routes.api
+	const { config } = useConfig();
+	const apiUrl = config.routes.api;
+	const { collectionSlug, id } = useDocumentInfo();
+	const hasReloadedAfterEncoding = useRef(false);
 
-  const [uploadId, setUploadId] = useState('')
-  const { assetId, setAssetId, title, setTitle, setFile, playbackUrl } = useFormFields(
-    ([fields, dispatch]) => ({
-      assetId: fields.assetId,
-      setAssetId: (assetId: string) =>
-        dispatch({ type: 'UPDATE', path: 'assetId', value: assetId }),
-      title: fields.title,
-      setTitle: (title: string) => dispatch({ type: 'UPDATE', path: 'title', value: title }),
-      // file: fields.file,
-      setFile: (file: File) => dispatch({ type: 'UPDATE', path: 'file', value: file }),
-      playbackUrl: fields['playbackOptions.0.playbackUrl']?.value,
-    }),
-  )
+	const [uploadId, setUploadId] = useState("");
+	const { assetId, setAssetId, title, setTitle, setFile, playbackUrl } =
+		useFormFields(([fields, dispatch]) => ({
+			assetId: fields.assetId,
+			setAssetId: (assetId: string) =>
+				dispatch({ type: "UPDATE", path: "assetId", value: assetId }),
+			title: fields.title,
+			setTitle: (title: string) =>
+				dispatch({ type: "UPDATE", path: "title", value: title }),
+			// file: fields.file,
+			setFile: (file: File) =>
+				dispatch({ type: "UPDATE", path: "file", value: file }),
+			playbackUrl: fields["playbackOptions.0.playbackUrl"]?.value,
+		}));
 
-  const { submit, setProcessing } = useForm()
+	const { submit, setProcessing } = useForm();
 
-  const getSignedUrl = useCallback(async () => {
-    // Fetch the signed URL from the API
-    const response = await fetch(`${apiUrl}/mux/upload`, {
-      method: 'POST',
-    })
+	const getSignedUrl = useCallback(async () => {
+		// Fetch the signed URL from the API
+		const response = await fetch(`${apiUrl}/mux/upload`, {
+			method: "POST",
+		});
 
-    // Parse the JSON response
-    const { id, url } = (await response.json()) as { id: string; url: string }
+		// Parse the JSON response
+		const { id, url } = (await response.json()) as { id: string; url: string };
 
-    // Update the upload ID
-    setUploadId(id)
+		// Update the upload ID
+		setUploadId(id);
 
-    // Return the URL
-    return url
-  }, [])
+		// Return the URL
+		return url;
+	}, []);
 
-  const onUploadStart = (args: any) => {
-    const {
-      detail: { file },
-    } = args
+	const onUploadStart = (args: any) => {
+		const {
+			detail: { file },
+		} = args;
 
-    // Remove the file extension from the name if it comes from the file input
-    const resolvedTitle = (title.value as string) || path.parse(file.name).name
+		// Remove the file extension from the name if it comes from the file input
+		const resolvedTitle = (title.value as string) || path.parse(file.name).name;
 
-    if (!title.value) {
-      setTitle(resolvedTitle)
-    }
+		if (!title.value) {
+			setTitle(resolvedTitle);
+		}
 
-    setFile(
-      new File([], resolvedTitle, {
-        type: file.type,
-        lastModified: file.lastModified,
-      }),
-    )
-  }
+		setFile(
+			new File([], resolvedTitle, {
+				type: file.type,
+				lastModified: file.lastModified,
+			}),
+		);
+	};
 
-  const onSuccess = async (args: any) => {
-    /* Show "Creating..." overlay */
-    setProcessing(true)
+	const onSuccess = async (args: any) => {
+		/* Show "Creating..." overlay */
+		setProcessing(true);
 
-    /* When the upload succeeded, get the Asset ID from the server */
-    let upload = await (
-      await fetch(`${apiUrl}/mux/upload?id=${uploadId}`, {
-        method: 'get',
-      })
-    ).json()
+		/* When the upload succeeded, get the Asset ID from the server */
+		let upload = await (
+			await fetch(`${apiUrl}/mux/upload?id=${uploadId}`, {
+				method: "get",
+			})
+		).json();
 
-    /* Sometimes the upload doesn't have the asset_id yet, poll every second until it does (this should only take a moment) */
-    while (!upload.asset_id) {
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-      upload = await (
-        await fetch(`${apiUrl}/mux/upload?id=${uploadId}`, {
-          method: 'get',
-        })
-      ).json()
-    }
+		/* Sometimes the upload doesn't have the asset_id yet, poll every second until it does (this should only take a moment) */
+		while (!upload.asset_id) {
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+			upload = await (
+				await fetch(`${apiUrl}/mux/upload?id=${uploadId}`, {
+					method: "get",
+				})
+			).json();
+		}
 
-    const { asset_id } = upload
+		const { asset_id } = upload;
 
-    /* Dispatch the ID field */
-    setAssetId(asset_id)
+		/* Dispatch the ID field */
+		setAssetId(asset_id);
 
-    /* Submit the form, use timeout to ensure setAssetId has been handled */
-    setTimeout(async () => {
-      await submit({
-        overrides: {
-          assetId: asset_id,
-        },
-      })
-    }, 0)
-  }
+		/* Submit the form, use timeout to ensure setAssetId has been handled */
+		setTimeout(async () => {
+			await submit({
+				overrides: {
+					assetId: asset_id,
+				},
+			});
+		}, 0);
+	};
 
-  /* When this is rendered, ensure the default .file-field is hidden */
-  /* We can't do this in CSS otherwise it hides .file-field(s) in other collections */
-  useEffect(() => {
-    if (window) {
-      const fileField = document.querySelector('.file-field') as HTMLElement
-      if (fileField) {
-        fileField.style.display = 'none'
-      }
-    }
-  }, [])
+	/* When this is rendered, ensure the default .file-field is hidden */
+	/* We can't do this in CSS otherwise it hides .file-field(s) in other collections */
+	useEffect(() => {
+		if (window) {
+			const fileField = document.querySelector(".file-field") as HTMLElement;
+			if (fileField) {
+				fileField.style.display = "none";
+			}
+		}
+	}, []);
 
-  //  There are three states: before upload, when we show the uploader. When the asset exists, we show the player. And when the asset is preparing, we show a message.
-  return (
-    <div className="mux-uploader">
-      {!assetId?.value && (
-        <MuxUploader
-          endpoint={getSignedUrl}
-          onUploadStart={onUploadStart}
-          onSuccess={onSuccess}
-        ></MuxUploader>
-      )}
+	useEffect(() => {
+		if (
+			!assetId?.value ||
+			playbackUrl ||
+			!collectionSlug ||
+			!id ||
+			hasReloadedAfterEncoding.current
+		) {
+			return;
+		}
 
-      {(assetId as any)?.value && !playbackUrl && (
-        <div className="mux-uploader__processing">
-          Video is being encoded. This typically takes less than 90 seconds, please refresh the page
-          in a moment
-        </div>
-      )}
-      {playbackUrl && (
-        <MuxPlayer src={playbackUrl as string} streamType="on-demand" style={{ height: '60vh' }} />
-      )}
-    </div>
-  )
-}
+		let isMounted = true;
+		let pollCount = 0;
 
-export default MuxUploaderField
+		const pollForEncodedVideo = async () => {
+			if (pollCount >= ENCODING_POLL_LIMIT) {
+				return;
+			}
+
+			pollCount += 1;
+
+			try {
+				const response = await fetch(
+					`${apiUrl}/${collectionSlug}/${id}?depth=2&draft=false`,
+				);
+
+				if (!response.ok) {
+					return;
+				}
+
+				const video = await response.json();
+
+				if (
+					isMounted &&
+					Array.isArray(video?.playbackOptions) &&
+					video.playbackOptions.length > 0 &&
+					!hasReloadedAfterEncoding.current
+				) {
+					hasReloadedAfterEncoding.current = true;
+					window.location.reload();
+				}
+			} catch (err) {
+				// Keep the admin UI in the encoding state if the temporary poll fails.
+			}
+		};
+
+		void pollForEncodedVideo();
+
+		const interval = window.setInterval(() => {
+			void pollForEncodedVideo();
+		}, ENCODING_POLL_INTERVAL);
+
+		return () => {
+			isMounted = false;
+			window.clearInterval(interval);
+		};
+	}, [apiUrl, assetId?.value, collectionSlug, id, playbackUrl]);
+
+	//  There are three states: before upload, when we show the uploader. When the asset exists, we show the player. And when the asset is preparing, we show a message.
+	return (
+		<div className="mux-uploader">
+			{!assetId?.value && (
+				<MuxUploader
+					endpoint={getSignedUrl}
+					onUploadStart={onUploadStart}
+					onSuccess={onSuccess}
+				></MuxUploader>
+			)}
+
+			{(assetId as any)?.value && !playbackUrl && (
+				<div className="mux-uploader__processing">
+					Video is being encoded. This typically takes less than 90 seconds,
+					please refresh the page in a moment
+				</div>
+			)}
+			{playbackUrl && (
+				<MuxPlayer
+					src={playbackUrl as string}
+					streamType="on-demand"
+					style={{ height: "60vh" }}
+				/>
+			)}
+		</div>
+	);
+};
+
+export default MuxUploaderField;

--- a/packages/mux-video/src/hooks/afterRead.ts
+++ b/packages/mux-video/src/hooks/afterRead.ts
@@ -1,0 +1,54 @@
+import type Mux from "@mux/mux-node";
+import type { CollectionAfterReadHook } from "payload";
+import { getAssetMetadata } from "../lib/getAssetMetadata";
+
+const getAfterReadMuxVideoHook = (
+	mux: Mux,
+	collection: string,
+): CollectionAfterReadHook => {
+	return async ({ req, doc, context }) => {
+		const hasPlaybackOptions =
+			Array.isArray(doc?.playbackOptions) && doc.playbackOptions.length > 0;
+
+		if (
+			(context as any)?.skipMuxVideoAfterReadSync ||
+			!doc?.assetId ||
+			hasPlaybackOptions
+		) {
+			return doc;
+		}
+
+		try {
+			const asset = await mux.video.assets.retrieve(doc.assetId);
+
+			if (asset.status !== "ready") {
+				return doc;
+			}
+
+			const metadata = getAssetMetadata(asset);
+
+			await req.payload.update({
+				collection,
+				id: doc.id,
+				data: metadata,
+				overrideAccess: true,
+				context: {
+					skipMuxVideoAfterReadSync: true,
+				},
+			});
+
+			return {
+				...doc,
+				...metadata,
+			};
+		} catch (err) {
+			req.payload.logger.error(
+				`[payload-mux] There was an error while syncing metadata for asset ${doc.assetId}:`,
+			);
+			req.payload.logger.error(err);
+			return doc;
+		}
+	};
+};
+
+export default getAfterReadMuxVideoHook;

--- a/packages/mux-video/src/hooks/beforeChange.ts
+++ b/packages/mux-video/src/hooks/beforeChange.ts
@@ -1,76 +1,89 @@
-import { CollectionBeforeChangeHook } from 'payload'
-import delay from '../lib/delay'
-import { getAssetMetadata } from '../lib/getAssetMetadata'
-import Mux from '@mux/mux-node'
+import type Mux from "@mux/mux-node";
+import type { CollectionBeforeChangeHook } from "payload";
+import delay from "../lib/delay";
+import { getAssetMetadata } from "../lib/getAssetMetadata";
 
-const getBeforeChangeMuxVideoHook = (mux: Mux, collection: string): CollectionBeforeChangeHook => {
-  return async ({ req, data: incomingData, operation, originalDoc }) => {
-    let data = { ...incomingData }
-    try {
-      if (!originalDoc?.assetId || originalDoc.assetId !== data.assetId) {
-        /* If this is an update, delete the old video first */
-        if (operation === 'update' && originalDoc.assetId !== data.assetId) {
-          await mux.video.assets.delete(originalDoc.assetId)
-        }
+const getBeforeChangeMuxVideoHook = (
+	mux: Mux,
+	collection: string,
+): CollectionBeforeChangeHook => {
+	return async ({ req, data: incomingData, operation, originalDoc }) => {
+		let data = { ...incomingData };
+		try {
+			const assetId = data.assetId;
+			const hasIncomingAsset =
+				typeof assetId === "string" && assetId.length > 0;
+			const hasAssetChanged =
+				hasIncomingAsset && originalDoc?.assetId !== assetId;
 
-        /* Now, get the asset and append its' information to the doc */
-        let asset = await mux.video.assets.retrieve(data.assetId)
-        /* Poll for up to 6 seconds, then the webhook will handle setting the metadata */
-        let delayDuration = 1500
-        const pollingLimit = 6
-        const timeout = Date.now() + pollingLimit * 1000
-        while (asset.status === 'preparing') {
-          if (Date.now() > timeout) {
-            break
-          }
-          await delay(delayDuration)
-          asset = await mux.video.assets.retrieve(data.assetId)
-        }
+			if (!originalDoc?.assetId || hasAssetChanged) {
+				if (!hasIncomingAsset) {
+					return data;
+				}
 
-        if (asset.status === 'errored') {
-          /* If the asset errored, delete it and throw an error */
-          await mux.video.assets.delete(data.assetId)
-          throw new Error(
-            `Unable to prepare asset: ${asset.status}. It's been deleted, please try again.`,
-          )
-        }
+				/* If this is an update, delete the old video first */
+				if (operation === "update" && hasAssetChanged) {
+					await mux.video.assets.delete(originalDoc.assetId);
+				}
 
-        /* If the asset is ready, we can get the metadata now */
-        if (asset.status === 'ready') {
-          data = {
-            ...data,
-            ...getAssetMetadata(asset),
-          }
-        }
+				/* Now, get the asset and append its' information to the doc */
+				let asset = await mux.video.assets.retrieve(assetId);
+				/* Poll for up to 6 seconds, then the webhook will handle setting the metadata */
+				const delayDuration = 1500;
+				const pollingLimit = 6;
+				const timeout = Date.now() + pollingLimit * 1000;
+				while (asset.status === "preparing") {
+					if (Date.now() > timeout) {
+						break;
+					}
+					await delay(delayDuration);
+					asset = await mux.video.assets.retrieve(assetId);
+				}
 
-        /* Override some of the built-in file data */
-        data.url = ''
+				if (asset.status === "errored") {
+					/* If the asset errored, delete it and throw an error */
+					await mux.video.assets.delete(assetId);
+					throw new Error(
+						`Unable to prepare asset: ${asset.status}. It's been deleted, please try again.`,
+					);
+				}
 
-        /* Ensure the title is unique, since we're setting the filename equal to the title and the filename must be unique */
-        const existingVideo = await req.payload.find({
-          collection,
-          where: {
-            title: {
-              contains: data.title,
-            },
-          },
-        })
+				/* If the asset is ready, we can get the metadata now */
+				if (asset.status === "ready") {
+					data = {
+						...data,
+						...getAssetMetadata(asset),
+					};
+				}
 
-        const uniqueTitle = `${data.title}${existingVideo.totalDocs > 0 ? ` (${existingVideo.totalDocs})` : ''}`
-        data.title = uniqueTitle
-        data.filename = uniqueTitle
-      }
-    } catch (err: unknown) {
-      req.payload.logger.error(
-        `[payload-mux] There was an error while uploading files corresponding to the collection with filename ${data.filename}:`,
-      )
-      req.payload.logger.error(err)
-      throw err
-    }
-    return {
-      ...data,
-    }
-  }
-}
+				/* Override some of the built-in file data */
+				data.url = "";
 
-export default getBeforeChangeMuxVideoHook
+				/* Ensure the title is unique, since we're setting the filename equal to the title and the filename must be unique */
+				const existingVideo = await req.payload.find({
+					collection,
+					where: {
+						title: {
+							contains: data.title,
+						},
+					},
+				});
+
+				const uniqueTitle = `${data.title}${existingVideo.totalDocs > 0 ? ` (${existingVideo.totalDocs})` : ""}`;
+				data.title = uniqueTitle;
+				data.filename = uniqueTitle;
+			}
+		} catch (err: unknown) {
+			req.payload.logger.error(
+				`[payload-mux] There was an error while uploading files corresponding to the collection with filename ${data.filename}:`,
+			);
+			req.payload.logger.error(err);
+			throw err;
+		}
+		return {
+			...data,
+		};
+	};
+};
+
+export default getBeforeChangeMuxVideoHook;

--- a/packages/mux-video/src/lib/getAssetMetadata.ts
+++ b/packages/mux-video/src/lib/getAssetMetadata.ts
@@ -1,21 +1,27 @@
-import { Asset } from '@mux/mux-node/resources/video/assets.mjs'
+import type { Asset } from "@mux/mux-node/resources/video/assets.mjs";
 
 export const getAssetMetadata = (asset: Asset) => {
-  const videoTrack = asset.tracks?.find((track: any) => track.type === 'video')!
+	const videoTrack = asset.tracks?.find((track: any) => track.type === "video");
 
-  return {
-    playbackOptions: asset.playback_ids?.map((value) => ({
-      playbackId: value.id,
-      playbackPolicy: value.policy,
-    })),
-    /* Reformat Mux's aspect ratio (e.g. 16:9) to be CSS-friendly (e.g. 16/9) */
-    aspectRatio: asset.aspect_ratio!.replace(':', '/'),
-    duration: asset.duration,
-    ...(videoTrack
-      ? {
-          maxWidth: videoTrack.max_width,
-          maxHeight: videoTrack.max_height,
-        }
-      : {}),
-  } as any
-}
+	return {
+		...(asset.playback_ids
+			? {
+					playbackOptions: asset.playback_ids.map((value) => ({
+						playbackId: value.id,
+						playbackPolicy: value.policy,
+					})),
+				}
+			: {}),
+		/* Reformat Mux's aspect ratio (e.g. 16:9) to be CSS-friendly (e.g. 16/9) */
+		...(asset.aspect_ratio
+			? { aspectRatio: asset.aspect_ratio.replace(":", "/") }
+			: {}),
+		...(typeof asset.duration === "number" ? { duration: asset.duration } : {}),
+		...(videoTrack
+			? {
+					maxWidth: videoTrack.max_width,
+					maxHeight: videoTrack.max_height,
+				}
+			: {}),
+	} as any;
+};


### PR DESCRIPTION
- Adds a fallback metadata sync for Mux videos that are saved before Mux has finished encoding.
- Adds admin-side polling while a video is missing playback metadata, so the "Video is being encoded" state updates automatically once Mux is ready.
- Fixes webhook error handling so internal failures return `500` instead of being acknowledged as successful.
- Verifies Mux webhook signatures against the raw request body.
- Preserves the previous local patch behavior:
  - enables Payload folders for the Mux video collection
  - places the collection in the `Assets` admin group

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oversightstudio/codesmith/payload-plugins/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786878463&installation_id=146511925&pr_number=34&repository=oversightstudio%2Fpayload-plugins&return_to=https%3A%2F%2Fgithub.com%2Foversightstudio%2Fpayload-plugins%2Fpull%2F34&signature=0c6201332fcd8942dd76d699233b44ec750a5a1009d6372127e2094fbe176256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->