### PR TITLE
fix: mux-video infinite encoding

### DIFF
--- a/packages/mux-video/src/collections/MuxVideo.ts
+++ b/packages/mux-video/src/collections/MuxVideo.ts
@@ -1,9 +1,10 @@
-import { CollectionConfig } from 'payload'
+import type Mux from '@mux/mux-node'
+import type { CollectionConfig } from 'payload'
 import getAfterDeleteMuxVideoHook from '../hooks/afterDelete'
+import getAfterReadMuxVideoHook from '../hooks/afterRead'
 import getBeforeChangeMuxVideoHook from '../hooks/beforeChange'
-import Mux from '@mux/mux-node'
-import { MuxVideoPluginOptions } from '../types'
 import { defaultAccessFunction } from '../lib/defaultAccessFunction'
+import type { MuxVideoPluginOptions } from '../types'
 
 export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): CollectionConfig => ({
   slug: (pluginOptions.extendCollection as string) ?? 'mux-video',
@@ -19,6 +20,9 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
     defaultColumns: ['title', 'muxUploader', 'duration'],
   },
   hooks: {
+    afterRead: [
+      getAfterReadMuxVideoHook(mux, (pluginOptions.extendCollection as string) ?? 'mux-video'),
+    ],
     afterDelete: [getAfterDeleteMuxVideoHook(mux)],
     beforeChange: [
       getBeforeChangeMuxVideoHook(mux, (pluginOptions.extendCollection as string) ?? 'mux-video'),
@@ -214,7 +218,10 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   const token = await mux.jwt.signPlaybackId(playbackId, {
                     expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
                     type: 'thumbnail',
-                    params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
+                    params:
+                      typeof posterTimestamp === 'number'
+                        ? { time: posterTimestamp.toString() }
+                        : undefined,
                   })
 
                   url.searchParams.set('token', token)
@@ -255,7 +262,10 @@ export const MuxVideo = (mux: Mux, pluginOptions: MuxVideoPluginOptions): Collec
                   const token = await mux.jwt.signPlaybackId(playbackId, {
                     expiration: pluginOptions.signedUrlOptions?.expiration ?? '1d',
                     type: 'gif',
-                    params: typeof posterTimestamp === 'number' ? { time: posterTimestamp.toString() } : undefined,
+                    params:
+                      typeof posterTimestamp === 'number'
+                        ? { time: posterTimestamp.toString() }
+                        : undefined,
                   })
 
                   url.searchParams.set('token', token)

--- a/packages/mux-video/src/endpoints/webhook.ts
+++ b/packages/mux-video/src/endpoints/webhook.ts
@@ -1,7 +1,7 @@
-import { PayloadHandler } from 'payload'
+import type Mux from '@mux/mux-node'
+import type { PayloadHandler } from 'payload'
 import { getAssetMetadata } from '../lib/getAssetMetadata'
-import Mux from '@mux/mux-node'
-import { MuxVideoPluginOptions } from '../types'
+import type { MuxVideoPluginOptions } from '../types'
 
 const handleAssetErrored = (req: any, assetId: string, errors: any) => {
   req.payload.logger.error(`[payload-mux] Error with assetId: ${assetId}`)
@@ -9,27 +9,38 @@ const handleAssetErrored = (req: any, assetId: string, errors: any) => {
 }
 
 const createSuccessResponse = () => new Response('Success!', { status: 200 })
-const createErrorResponse = () => new Response('Error', { status: 204 })
+const createErrorResponse = () => new Response('Error', { status: 500 })
 
 export const muxWebhooksHandler =
   (mux: Mux, pluginOptions: MuxVideoPluginOptions): PayloadHandler =>
   async (req) => {
-    if (!req.json) {
-      return Response.error()
+    if (!req.text) {
+      return new Response('Invalid request', { status: 400 })
     }
 
-    const body = await req.json()
+    let event: any
 
-    if (!body) {
-      return Response.error()
+    try {
+      const rawBody = await req.text()
+      mux.webhooks.verifySignature(rawBody, req.headers)
+      event = JSON.parse(rawBody)
+    } catch (err) {
+      req.payload.logger.error('[payload-mux] Invalid Mux webhook request:')
+      req.payload.logger.error(err)
+      return new Response('Invalid Mux webhook request', { status: 400 })
     }
 
-    mux.webhooks.verifySignature(JSON.stringify(body), req.headers)
+    if (!event) {
+      return new Response('Invalid Mux webhook payload', { status: 400 })
+    }
 
     const collection = (pluginOptions.extendCollection as string) ?? 'mux-video'
 
-    const event = body
-    const assetId = event.object?.id
+    const assetId = event.object?.id ?? event.data?.id
+
+    if (!assetId) {
+      return createSuccessResponse()
+    }
 
     const videos = await req.payload.find({
       collection,
@@ -61,6 +72,10 @@ export const muxWebhooksHandler =
             },
           })
         } catch (err) {
+          req.payload.logger.error(
+            `[payload-mux] There was an error while creating video for asset ${assetId}:`,
+          )
+          req.payload.logger.error(err)
           return createErrorResponse()
         }
       }
@@ -80,6 +95,10 @@ export const muxWebhooksHandler =
             },
           })
         } catch (err) {
+          req.payload.logger.error(
+            `[payload-mux] There was an error while updating video for asset ${assetId}:`,
+          )
+          req.payload.logger.error(err)
           return createErrorResponse()
         }
         break
@@ -92,6 +111,10 @@ export const muxWebhooksHandler =
             id: video.id,
           })
         } catch (err) {
+          req.payload.logger.error(
+            `[payload-mux] There was an error while deleting video for asset ${assetId}:`,
+          )
+          req.payload.logger.error(err)
           return createErrorResponse()
         }
         break

--- a/packages/mux-video/src/fields/mux-uploader/mux-uploader.tsx
+++ b/packages/mux-video/src/fields/mux-uploader/mux-uploader.tsx
@@ -1,15 +1,20 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
 import MuxPlayer from '@mux/mux-player-react'
 import MuxUploader from '@mux/mux-uploader-react'
-import { useConfig, useForm, useFormFields } from '@payloadcms/ui'
+import { useConfig, useDocumentInfo, useForm, useFormFields } from '@payloadcms/ui'
 import path from 'path'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import './mux-uploader.scss'
+
+const ENCODING_POLL_INTERVAL = 5000
+const ENCODING_POLL_LIMIT = 36
 
 export const MuxUploaderField = () => {
   const { config } = useConfig()
   const apiUrl = config.routes.api
+  const { collectionSlug, id } = useDocumentInfo()
+  const hasReloadedAfterEncoding = useRef(false)
 
   const [uploadId, setUploadId] = useState('')
   const { assetId, setAssetId, title, setTitle, setFile, playbackUrl } = useFormFields(
@@ -109,6 +114,62 @@ export const MuxUploaderField = () => {
       }
     }
   }, [])
+
+  useEffect(() => {
+    if (
+      !assetId?.value ||
+      playbackUrl ||
+      !collectionSlug ||
+      !id ||
+      hasReloadedAfterEncoding.current
+    ) {
+      return
+    }
+
+    let isMounted = true
+    let pollCount = 0
+
+    const pollForEncodedVideo = async () => {
+      if (pollCount >= ENCODING_POLL_LIMIT) {
+        return
+      }
+
+      pollCount += 1
+
+      try {
+        const response = await fetch(`${apiUrl}/${collectionSlug}/${id}?depth=2&draft=false`)
+
+        if (!response.ok) {
+          return
+        }
+
+        const video = await response.json()
+
+        if (
+          isMounted &&
+          Array.isArray(video?.playbackOptions) &&
+          video.playbackOptions.length > 0 &&
+          !hasReloadedAfterEncoding.current
+        ) {
+          hasReloadedAfterEncoding.current = true
+          window.location.reload()
+        }
+      } catch (err) {
+        // Keep the admin UI in the encoding state if the temporary poll fails.
+      }
+    }
+
+    void pollForEncodedVideo()
+
+    const interval = window.setInterval(() => {
+      void pollForEncodedVideo()
+    }, ENCODING_POLL_INTERVAL)
+
+    return () => {
+      isMounted = false
+      window.clearInterval(interval)
+    }
+  }, [apiUrl, assetId?.value, collectionSlug, id, playbackUrl])
 
   //  There are three states: before upload, when we show the uploader. When the asset exists, we show the player. And when the asset is preparing, we show a message.
   return (

--- a/packages/mux-video/src/hooks/afterRead.ts
+++ b/packages/mux-video/src/hooks/afterRead.ts
@@ -1,0 +1,46 @@
+import type Mux from '@mux/mux-node'
+import type { CollectionAfterReadHook } from 'payload'
+import { getAssetMetadata } from '../lib/getAssetMetadata'
+
+const getAfterReadMuxVideoHook = (mux: Mux, collection: string): CollectionAfterReadHook => {
+  return async ({ req, doc, context }) => {
+    const hasPlaybackOptions = Array.isArray(doc?.playbackOptions) && doc.playbackOptions.length > 0
+
+    if ((context as any)?.skipMuxVideoAfterReadSync || !doc?.assetId || hasPlaybackOptions) {
+      return doc
+    }
+
+    try {
+      const asset = await mux.video.assets.retrieve(doc.assetId)
+
+      if (asset.status !== 'ready') {
+        return doc
+      }
+
+      const metadata = getAssetMetadata(asset)
+
+      await req.payload.update({
+        collection,
+        id: doc.id,
+        data: metadata,
+        overrideAccess: true,
+        context: {
+          skipMuxVideoAfterReadSync: true,
+        },
+      })
+
+      return {
+        ...doc,
+        ...metadata,
+      }
+    } catch (err) {
+      req.payload.logger.error(
+        `[payload-mux] There was an error while syncing metadata for asset ${doc.assetId}:`,
+      )
+      req.payload.logger.error(err)
+      return doc
+    }
+  }
+}
+
+export default getAfterReadMuxVideoHook

--- a/packages/mux-video/src/hooks/beforeChange.ts
+++ b/packages/mux-video/src/hooks/beforeChange.ts
@@ -1,22 +1,30 @@
-import { CollectionBeforeChangeHook } from 'payload'
+import type Mux from '@mux/mux-node'
+import type { CollectionBeforeChangeHook } from 'payload'
 import delay from '../lib/delay'
 import { getAssetMetadata } from '../lib/getAssetMetadata'
-import Mux from '@mux/mux-node'
 
 const getBeforeChangeMuxVideoHook = (mux: Mux, collection: string): CollectionBeforeChangeHook => {
   return async ({ req, data: incomingData, operation, originalDoc }) => {
     let data = { ...incomingData }
     try {
-      if (!originalDoc?.assetId || originalDoc.assetId !== data.assetId) {
+      const assetId = data.assetId
+      const hasIncomingAsset = typeof assetId === 'string' && assetId.length > 0
+      const hasAssetChanged = hasIncomingAsset && originalDoc?.assetId !== assetId
+
+      if (!originalDoc?.assetId || hasAssetChanged) {
+        if (!hasIncomingAsset) {
+          return data
+        }
+
         /* If this is an update, delete the old video first */
-        if (operation === 'update' && originalDoc.assetId !== data.assetId) {
+        if (operation === 'update' && hasAssetChanged) {
           await mux.video.assets.delete(originalDoc.assetId)
         }
 
         /* Now, get the asset and append its' information to the doc */
-        let asset = await mux.video.assets.retrieve(data.assetId)
+        let asset = await mux.video.assets.retrieve(assetId)
         /* Poll for up to 6 seconds, then the webhook will handle setting the metadata */
-        let delayDuration = 1500
+        const delayDuration = 1500
         const pollingLimit = 6
         const timeout = Date.now() + pollingLimit * 1000
         while (asset.status === 'preparing') {
@@ -24,12 +32,12 @@ const getBeforeChangeMuxVideoHook = (mux: Mux, collection: string): CollectionBe
             break
           }
           await delay(delayDuration)
-          asset = await mux.video.assets.retrieve(data.assetId)
+          asset = await mux.video.assets.retrieve(assetId)
         }
 
         if (asset.status === 'errored') {
           /* If the asset errored, delete it and throw an error */
-          await mux.video.assets.delete(data.assetId)
+          await mux.video.assets.delete(assetId)
           throw new Error(
             `Unable to prepare asset: ${asset.status}. It's been deleted, please try again.`,
           )

--- a/packages/mux-video/src/lib/getAssetMetadata.ts
+++ b/packages/mux-video/src/lib/getAssetMetadata.ts
@@ -1,16 +1,20 @@
-import { Asset } from '@mux/mux-node/resources/video/assets.mjs'
+import type { Asset } from '@mux/mux-node/resources/video/assets.mjs'
 
 export const getAssetMetadata = (asset: Asset) => {
-  const videoTrack = asset.tracks?.find((track: any) => track.type === 'video')!
+  const videoTrack = asset.tracks?.find((track: any) => track.type === 'video')
 
   return {
-    playbackOptions: asset.playback_ids?.map((value) => ({
-      playbackId: value.id,
-      playbackPolicy: value.policy,
-    })),
+    ...(asset.playback_ids
+      ? {
+          playbackOptions: asset.playback_ids.map((value) => ({
+            playbackId: value.id,
+            playbackPolicy: value.policy,
+          })),
+        }
+      : {}),
     /* Reformat Mux's aspect ratio (e.g. 16:9) to be CSS-friendly (e.g. 16/9) */
-    aspectRatio: asset.aspect_ratio!.replace(':', '/'),
-    duration: asset.duration,
+    ...(asset.aspect_ratio ? { aspectRatio: asset.aspect_ratio.replace(':', '/') } : {}),
+    ...(typeof asset.duration === 'number' ? { duration: asset.duration } : {}),
     ...(videoTrack
       ? {
           maxWidth: videoTrack.max_width,


### PR DESCRIPTION
- Adds a fallback metadata sync for Mux videos that are saved before Mux has finished encoding.
- Adds admin-side polling while a video is missing playback metadata, so the "Video is being encoded" state updates automatically once Mux is ready.
- Fixes webhook error handling so internal failures return 500 instead of being acknowledged as successful.
- Verifies Mux webhook signatures against the raw request body.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oversightstudio/codesmith/payload-plugins/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786887377&installation_id=146511925&pr_number=35&repository=oversightstudio%2Fpayload-plugins&return_to=https%3A%2F%2Fgithub.com%2Foversightstudio%2Fpayload-plugins%2Fpull%2F35&signature=dc38ce4434b5702f1c01e1893bdda59458ea6a3eff5b64500d185d2dab4547c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->